### PR TITLE
Fix the reference to "Object Notifications" Swift example

### DIFF
--- a/source/ios/notifications.txt
+++ b/source/ios/notifications.txt
@@ -163,7 +163,7 @@ and whether the object was deleted.
     .. tab::
         :tabid: swift
 
-        .. literalinclude:: /examples/generated/code/start/Notifications.codeblock.register-a-collection-change-listener.swift
+        .. literalinclude:: /examples/generated/code/start/Notifications.codeblock.register-an-object-change-listener.swift
           :language: swift
 
     .. tab::


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-NNNN

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/NNNNNNN/java/docsworker-xlarge/NNNNNNNNNNN/
